### PR TITLE
fix StreamDeckWS with two WS

### DIFF
--- a/Sources/org.tynsoe.streamdeck.wsproxy.sdPlugin/plugin/index.js
+++ b/Sources/org.tynsoe.streamdeck.wsproxy.sdPlugin/plugin/index.js
@@ -116,7 +116,7 @@ function connect(remoteServer,position,message,backend_only=false) {
 	c.onopen = function(evt) {
 		console.log("Remote socket opened")
 		if (message) {
-			c.send(JSON.stringify(message))
+			connections[remoteServer].websocket.send(JSON.stringify(message))
 		}
 	}
 


### PR DESCRIPTION
Last weekend I was (mostly successfully) including your StreamDeck plugin WS into my workflow. Thanks for the great work.

I did run into a problem though. My Setup is as follows:
- TWO WebSockets in NodeRed (each of the WS serves multiple actions, inside NodeRed connected such, that they work as radio buttons)
- All actions read/write to HomeKit devices (should not matter though, but mentioned for completeness).
- On willAppear I perform initialisation, I.e. determine the HomeKit state of the Lamp and send an appropriate image back to the button

Everything works fine with just one WS. With the TWO WebSockets I get,

1. a number of correct willAppear Events on the First WS
2. a superfluous willAppear on the First WS, which is actually supposed to appear on the Second WS
3. the remaining willAppear Events on the SecondWS

> I was able to clone your github Project and run that code instead of the prebuilt plugin. But I am stuck howoever on basic stuff as to find where the console.logs() appear, which limits my reverse eng. capabilities a bit 😉.
> 
> I think I understood the overall structure of your code, and can see where (and why) you delay follow up messages. Indeed the correct one (3) for the second WS is the delayed message for the second WS. The problem seems to be somewhere in connect(), where the initial event for each WS is sent. Somehow the second connection (remoteServer two) gets assigned the same WebSocket as the first one.
> 

I suspect the problem is somewhere in c.onopen= (), potentially the 'captured variable "c"' is overwritten as the button initialisations from StreamDeck are faster than the sockets can be opened.


I think I found a solution to the problem, please see attached pull request. I guess there might be a better solution with changing the scope of "c", so its properly captured, but the attached modification does the trick.
