### PR TITLE
Add support for dials/encoders in Stream Deck+

### DIFF
--- a/Sources/org.tynsoe.streamdeck.wsproxy.sdPlugin/manifest.json
+++ b/Sources/org.tynsoe.streamdeck.wsproxy.sdPlugin/manifest.json
@@ -8,7 +8,14 @@
                 {
                     "Image": "images/websocket"
                 }
-            ]
+            ],
+            "Controllers": [
+                "Keypad",
+                "Encoder"
+            ],
+            "Encoder": {
+                "layout": "$B1"
+            }
         },
         {
             "UUID": "org.tynsoe.streamdeck.wsproxy.proxy-ms",
@@ -31,7 +38,7 @@
     "Name": "WebSocket Proxy",
     "Icon": "images/websocket",
     "SDKVersion": 2,
-    "Version": "1.1.9",
+    "Version": "1.2.0",
     "PropertyInspectorPath": "plugin/inspector.html",
     "OS": [
         {


### PR DESCRIPTION
This adds support for the Stream Deck+ with its dials.
Thanks to the current event agnostic behavior of StreamDeckWS, the dial events are passed over Websocket without any additional changes.

It's debatable what the default layout should be. Currently set to `"layout": "$B1"`, which is one of the most common one. Maybe it should be possible to change the layout from the Property Inspector but I didn't want to go that far. It's still possible to dynamically update the layout by sending a message from Node-RED.

The provided screenshot shows an example flow which converts incoming message to JSON, elevate the payload one level up in the Node-RED `msg`. Checks for ID `Dial1` and then switches on the event type. On `willAppear`, the currently stored value is sent. On `dialRotate` the value is updated and sent back to Stream Deck to get it reflected on screen.

![image](https://user-images.githubusercontent.com/195860/211388102-ebd25ccd-039f-4c94-9578-de2e89731049.png)

![image](https://user-images.githubusercontent.com/195860/211388696-645acf01-8661-46a3-8022-c23d4a3e5a19.png)

